### PR TITLE
Add initial ecommerce models

### DIFF
--- a/buildmart-online/backend/buildmart/settings/base.py
+++ b/buildmart-online/backend/buildmart/settings/base.py
@@ -78,3 +78,4 @@ USE_TZ = True
 STATIC_URL = '/static/'
 STATIC_ROOT = BASE_DIR / 'static'
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+AUTH_USER_MODEL = 'users.User'

--- a/buildmart-online/backend/cart/models.py
+++ b/buildmart-online/backend/cart/models.py
@@ -1,0 +1,27 @@
+from django.db import models
+from django.contrib.auth import get_user_model
+from catalog.models import Product
+
+User = get_user_model()
+
+
+class Cart(models.Model):
+    user = models.OneToOneField(User, on_delete=models.CASCADE, related_name='cart')
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    def __str__(self):
+        return f"Cart of {self.user.username}"
+
+
+class CartItem(models.Model):
+    cart = models.ForeignKey(Cart, on_delete=models.CASCADE, related_name='items')
+    product = models.ForeignKey(Product, on_delete=models.CASCADE)
+    quantity = models.IntegerField()
+    added_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        unique_together = ('cart', 'product')
+
+    def __str__(self):
+        return f"{self.product.name} x {self.quantity}"

--- a/buildmart-online/backend/catalog/models.py
+++ b/buildmart-online/backend/catalog/models.py
@@ -1,0 +1,95 @@
+from django.db import models
+
+
+class Category(models.Model):
+    name = models.CharField(max_length=255)
+    description = models.TextField(blank=True)
+    parent = models.ForeignKey(
+        'self', on_delete=models.SET_NULL, null=True, blank=True, related_name='children'
+    )
+    image_url = models.CharField(max_length=255, blank=True)
+    display_order = models.IntegerField(default=0)
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        verbose_name_plural = 'Categories'
+        ordering = ['display_order', 'name']
+
+    def __str__(self):
+        return self.name
+
+
+class Brand(models.Model):
+    name = models.CharField(max_length=255, unique=True)
+    description = models.TextField(blank=True)
+    logo_url = models.CharField(max_length=255, blank=True)
+    website = models.CharField(max_length=255, blank=True)
+    is_active = models.BooleanField(default=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    def __str__(self):
+        return self.name
+
+
+class Product(models.Model):
+    name = models.CharField(max_length=255)
+    description = models.TextField(blank=True)
+    category = models.ForeignKey(Category, on_delete=models.PROTECT)
+    brand = models.ForeignKey(Brand, on_delete=models.SET_NULL, null=True, blank=True)
+    price = models.DecimalField(max_digits=10, decimal_places=2)
+    stock_quantity = models.IntegerField(default=0)
+    is_active = models.BooleanField(default=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    def __str__(self):
+        return self.name
+
+
+class ProductImage(models.Model):
+    product = models.ForeignKey(Product, on_delete=models.CASCADE, related_name='images')
+    image_url = models.CharField(max_length=255)
+    alt_text = models.CharField(max_length=255, blank=True)
+    is_primary = models.BooleanField(default=False)
+    display_order = models.IntegerField(default=0)
+    uploaded_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        ordering = ['display_order']
+
+    def __str__(self):
+        return f"{self.product.name} image"
+
+
+class SpecificationType(models.Model):
+    name = models.CharField(max_length=255)
+    data_type = models.CharField(max_length=50)
+    unit = models.CharField(max_length=50, blank=True)
+    category = models.ForeignKey(Category, on_delete=models.SET_NULL, null=True, blank=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    def __str__(self):
+        return self.name
+
+
+class ProductSpecification(models.Model):
+    product = models.ForeignKey(Product, on_delete=models.CASCADE, related_name='specifications')
+    specification_type = models.ForeignKey(SpecificationType, on_delete=models.CASCADE)
+    value = models.TextField()
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    def __str__(self):
+        return f"{self.specification_type.name}: {self.value}"
+
+
+class ProductVariant(models.Model):
+    product = models.ForeignKey(Product, on_delete=models.CASCADE, related_name='variants')
+    variant_name = models.CharField(max_length=255)
+    price_difference = models.DecimalField(max_digits=10, decimal_places=2, default=0)
+    stock_quantity = models.IntegerField(default=0)
+    sku = models.CharField(max_length=100, blank=True)
+    is_active = models.BooleanField(default=True)
+
+    def __str__(self):
+        return f"{self.product.name} - {self.variant_name}"

--- a/buildmart-online/backend/orders/models.py
+++ b/buildmart-online/backend/orders/models.py
@@ -1,0 +1,38 @@
+from django.db import models
+from django.contrib.auth import get_user_model
+from catalog.models import Product
+
+User = get_user_model()
+
+
+class Order(models.Model):
+    STATUS_CHOICES = [
+        ('Pending', 'Pending'),
+        ('Processing', 'Processing'),
+        ('Shipped', 'Shipped'),
+        ('Delivered', 'Delivered'),
+        ('Cancelled', 'Cancelled'),
+    ]
+
+    user = models.ForeignKey(User, on_delete=models.PROTECT)
+    order_number = models.CharField(max_length=50, unique=True)
+    total_amount = models.DecimalField(max_digits=12, decimal_places=2)
+    status = models.CharField(max_length=20, choices=STATUS_CHOICES, default='Pending')
+    shipping_address = models.TextField(blank=True)
+    payment_status = models.CharField(max_length=20, default='Pending')
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    def __str__(self):
+        return self.order_number
+
+
+class OrderItem(models.Model):
+    order = models.ForeignKey(Order, on_delete=models.CASCADE, related_name='items')
+    product = models.ForeignKey(Product, on_delete=models.PROTECT)
+    quantity = models.IntegerField()
+    price_at_purchase = models.DecimalField(max_digits=10, decimal_places=2)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    def __str__(self):
+        return f"{self.product.name} x {self.quantity}"

--- a/buildmart-online/backend/users/models.py
+++ b/buildmart-online/backend/users/models.py
@@ -1,0 +1,15 @@
+from django.db import models
+from django.contrib.auth.models import AbstractUser
+
+
+class User(AbstractUser):
+    ROLE_CHOICES = [
+        ('customer', 'Customer'),
+        ('admin', 'Admin'),
+        ('supplier', 'Supplier'),
+    ]
+    role = models.CharField(max_length=20, choices=ROLE_CHOICES, default='customer')
+    is_active = models.BooleanField(default=True)
+
+    def __str__(self):
+        return self.username

--- a/recommendation/README.md
+++ b/recommendation/README.md
@@ -1,0 +1,14 @@
+# Recommendation Example
+
+This folder contains a simple item-based collaborative filtering example.
+
+`sample_events.csv` holds sample click events for a few products. The
+`recommender.py` script computes product-to-product similarity using
+Jaccard similarity of users who viewed each item and prints some example
+recommendations.
+
+Run it with:
+
+```bash
+python recommendation/recommender.py
+```

--- a/recommendation/recommender.py
+++ b/recommendation/recommender.py
@@ -1,0 +1,48 @@
+import csv
+import os
+from collections import defaultdict
+from typing import List
+
+class ItemBasedRecommender:
+    def __init__(self, events_path: str):
+        self.events_path = events_path
+        self.product_users = defaultdict(set)
+        self.similarity = {}
+
+    def load_events(self):
+        with open(self.events_path, newline="") as f:
+            reader = csv.DictReader(f)
+            for row in reader:
+                self.product_users[row["product_id"]].add(row["user_id"])
+
+    def train(self):
+        self.load_events()
+        products = list(self.product_users.keys())
+        for i, p1 in enumerate(products):
+            for p2 in products[i+1:]:
+                users1 = self.product_users[p1]
+                users2 = self.product_users[p2]
+                if not users1 or not users2:
+                    score = 0.0
+                else:
+                    score = len(users1 & users2) / len(users1 | users2)
+                if score > 0:
+                    self.similarity.setdefault(p1, {})[p2] = score
+                    self.similarity.setdefault(p2, {})[p1] = score
+
+    def recommend(self, product_id: str, top_n: int = 3) -> List[str]:
+        if product_id not in self.similarity:
+            return []
+        similar_items = sorted(self.similarity[product_id].items(), key=lambda x: x[1], reverse=True)
+        return [item for item, _ in similar_items[:top_n]]
+
+def main():
+    base = os.path.dirname(__file__)
+    rec = ItemBasedRecommender(os.path.join(base, 'sample_events.csv'))
+    rec.train()
+    for pid in ['p1', 'p2', 'p3', 'p4', 'p5']:
+        recs = rec.recommend(pid)
+        print(f'Recommendations for {pid}: {recs}')
+
+if __name__ == '__main__':
+    main()

--- a/recommendation/sample_events.csv
+++ b/recommendation/sample_events.csv
@@ -1,0 +1,12 @@
+user_id,product_id,event_type
+u1,p1,view
+u1,p2,view
+u1,p3,view
+u2,p2,view
+u2,p3,view
+u3,p1,view
+u3,p4,view
+u4,p5,view
+u4,p2,view
+u5,p1,view
+u5,p3,view

--- a/recommendation/sample_products.csv
+++ b/recommendation/sample_products.csv
@@ -1,0 +1,6 @@
+product_id,name
+p1,Brick
+p2,Cement
+p3,Paint
+p4,Sand
+p5,Drill


### PR DESCRIPTION
## Summary
- implement Category, Brand, Product, ProductImage and specs models
- implement Cart and Order models with relations
- add custom User model and set `AUTH_USER_MODEL`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684160a4be108326a0c92e99a2e3155c